### PR TITLE
Changes to accomodate RAMLINK XL

### DIFF
--- a/ramlink/ramlink-copy.c
+++ b/ramlink/ramlink-copy.c
@@ -36,7 +36,7 @@ void ramlink_reu_copy(unsigned long reu_address, void *c64_address, unsigned int
 	RAMLINK_REU.reu_address = reu_address & 0xffff;
 	RAMLINK_REU.reu_bank = reu_address >> 16;
 	RAMLINK_REU.length = length;
-	RAMLINK_REU.address_control = 0;
+	RAMLINK_REU.address_control = (reu_address >> 24) & 0x003f; //RAMLINK XL THE HIGH BITS HERE
 	RAMLINK_REU.command = REU_COMMAND_EXECUTE | mode;
 
 	ramlink_reu_execute_and_disable();

--- a/ramlink/ramlink-detect.c
+++ b/ramlink/ramlink-detect.c
@@ -28,10 +28,21 @@
 */
 
 #include "ramlink.h"
+#include "../drive/drive.h"
+#include <string.h>
+
+static unsigned char ramxlrom[] = "cmd rl dos v2.10";
 
 bool ramlink_detect(void) {
 	if (*(unsigned char *)0xe0a9 == 0x78) {
 		return true;
 	}
 	return false;
+}
+
+bool ramlink_xl_detect(uint8_t device_id) {
+    if (strcmp(ramxlrom, drive_identify(device_id)) == 0) {
+        return true;
+    }
+    return false;
 }

--- a/ramlink/ramlink-get-size.c
+++ b/ramlink/ramlink-get-size.c
@@ -61,7 +61,7 @@ unsigned long ramlink_get_size(uint8_t device_id) {
 			((unsigned long)block[22] << 16) | 
 			((unsigned long)block[23] << 8)  | 
 			((unsigned long)block[24]));
-	if((unsigned long)block[21]) {
+   if( ramlink_xl_detect(device_id)) {
         size = size + 0x10000; // RAMLINK XL
 	} else {
 		size = size + 0x1000;  // RAMLINK

--- a/ramlink/ramlink-get-size.c
+++ b/ramlink/ramlink-get-size.c
@@ -56,8 +56,15 @@ unsigned long ramlink_get_size(uint8_t device_id) {
 		}
 		++i;
 	}
-
-	size = (((unsigned long)block[22] << 16) | ((unsigned int)block[23] << 8) | block[24]) + 0x1000;
-
+	
+	size = (((unsigned long)block[21] << 24) |
+			((unsigned long)block[22] << 16) | 
+			((unsigned long)block[23] << 8)  | 
+			((unsigned long)block[24]));
+	if((unsigned long)block[21]) {
+        size = size + 0x10000; // RAMLINK XL
+	} else {
+		size = size + 0x1000;  // RAMLINK
+	}
 	return size;
 }

--- a/ramlink/ramlink.h
+++ b/ramlink/ramlink.h
@@ -98,6 +98,7 @@ void ramlink_reu_dma(unsigned char mode, unsigned int ramlink_page, unsigned int
 void ramlink_reu_copy(unsigned long ramlink_address, void *c64_address, unsigned int length, unsigned char mode);
 unsigned char ramlink_copy_block(unsigned char partition, unsigned char track, unsigned char sector, void *c64_address, unsigned char job);
 bool ramlink_detect(void);
+bool ramlink_xl_detect(uint8_t device_id);
 unsigned long ramlink_get_size(uint8_t device_id);
 struct tm *ramlink_get_time(unsigned char device);
 

--- a/src/backup-dos.c
+++ b/src/backup-dos.c
@@ -35,10 +35,10 @@
 bool backup_dos(void) {
     static unsigned long address;
     
-    printf("Saving RAMLink to disk:   0 of %3u", (unsigned int)(ramlink_size >> 16));
+    printf("Saving RAMLink to disk:    0 of %4u", (unsigned int)(ramlink_size >> 16));
     for (address = 0; address < ramlink_size; address += BUFFER_SIZE) {
         gotox(0);
-        printf("Saving RAMLink to disk: %3u", (unsigned int)(address>>16));
+        printf("Saving RAMLink to disk: %4u", (unsigned int)(address>>16));
 #if ENABLE_RAMLINK
         ramlink_reu_copy(address, buffer, BUFFER_SIZE, REU_COMMAND_REU_TO_C64);
 #endif
@@ -51,7 +51,7 @@ bool backup_dos(void) {
     }
     
     gotox(0);
-    printf("Saving RAMLink to disk: %3u\n", (unsigned int)(address>>16));
+    printf("Saving RAMLink to disk: %4u\n", (unsigned int)(address>>16));
         
     return true;
 }

--- a/src/backup-reu.c
+++ b/src/backup-reu.c
@@ -34,29 +34,36 @@
 
 bool backup_reu(void) {
     static unsigned long address;
+    static unsigned long block_start = 0;
+    unsigned int reu_block = 0;
+    unsigned int nblocks = (ramlink_size + reu_size - 1)/reu_size;
     
-    printf("Copying RAMLink to REU:   0 of %3u", (unsigned int)(ramlink_size >> 16));
-    for (address = 0; address < ramlink_size; address += BUFFER_SIZE) {
-        gotox(0);
-        printf("Copying RAMLink to REU: %3u", (unsigned int)(address>>16));
+    printf("Copying RAMLink to REU:    0 of %4u\n", (unsigned int)(ramlink_size >> 16));
+    printf("Saving REU:  0 of %2u", nblocks);
+    gotoxy(0, wherey() - 1);
+    while(reu_block < nblocks){
+        for (address = block_start; address < block_start + reu_size && address < ramlink_size; address += BUFFER_SIZE) {
+            gotox(0);
+            printf("Copying RAMLink to REU: %4u", (unsigned int)(address>>16));
 #if ENABLE_RAMLINK
-        ramlink_reu_copy(address, buffer, BUFFER_SIZE, REU_COMMAND_REU_TO_C64);
+            ramlink_reu_copy(address, buffer, BUFFER_SIZE, REU_COMMAND_REU_TO_C64);
 #endif
 #if ENABLE_REU
-        reu_copy(address, buffer, BUFFER_SIZE, REU_COMMAND_C64_TO_REU);
+            reu_copy(address - block_start, buffer, BUFFER_SIZE, REU_COMMAND_C64_TO_REU);
 #endif
-    }
-    gotox(0);
-    printf("Copying RAMLink to REU: %3u\n", (unsigned int)(address>>16));
-    
-    printf("Saving REU.\n");
-    
+        }
+        printf("\nSaving REU: %2u", reu_block + 1);
 #if ENABLE_DOS
-    if (ultimate_dos_save_reu(1, 0, ramlink_size) != NULL) {
-        printf("Can't save REU: %s\n", ultimate_ci_status);
-        return false;
-    }
+        if (ultimate_dos_save_reu(1, 0, reu_size) != NULL) {
+            printf("Can't save REU: %s\n", ultimate_ci_status);
+            return false;
+        }
 #endif
-    
+        gotoxy(0, wherey() - 1);
+        ++reu_block;
+        block_start += reu_size;
+    }
+    printf("Copying RAMLink to REU: %4u", (unsigned int)(address>>16));
+    gotoxy(0, wherey() + 2);
     return true;
 }

--- a/src/backup-reu.c
+++ b/src/backup-reu.c
@@ -33,8 +33,8 @@
 #include <stdio.h>
 
 bool backup_reu(void) {
-    static unsigned long address;
-    static unsigned long block_start = 0;
+    unsigned long address = 0;
+    unsigned long block_start = 0;
     unsigned int reu_block = 0;
     unsigned int nblocks = (ramlink_size + reu_size - 1)/reu_size;
     

--- a/src/detect.c
+++ b/src/detect.c
@@ -95,8 +95,12 @@ bool detect(void) {
     }
     else {
         textcolor(COLOR_LIGHTGREEN);
-        printf("Drive %u, ", ramlink_device);
-        
+        if(ramlink_xl_detect(ramlink_device)){
+            printf("XL, Drive %u, ", ramlink_device);
+        }
+        else {
+            printf("Drive %u, ", ramlink_device);
+        }
         if ((ramlink_size = ramlink_get_size(ramlink_device)) == 0) {
             textcolor(COLOR_LIGHTRED);
             printf("missing system partition\n");

--- a/src/restore-dos.c
+++ b/src/restore-dos.c
@@ -35,10 +35,10 @@
 bool restore_dos(void) {
     static unsigned long address;
     
-    printf("Loading RAMLink from disk:   0 of %3u", (unsigned int)(ramlink_size >> 16));
+    printf("Loading RAMLink from disk:    0 of %4u", (unsigned int)(ramlink_size >> 16));
     for (address = 0; address < ramlink_size; address += BUFFER_SIZE) {
         gotox(0);
-        printf("Loading RAMLink from disk: %3u\n", (unsigned int)(address>>16));
+        printf("Loading RAMLink from disk: %4u", (unsigned int)(address>>16));
 #if ENABLE_DOS
         if (ultimate_dos_read_data(1, buffer, BUFFER_SIZE) != BUFFER_SIZE) {
             printf("Read error: %s\n", ultimate_ci_status);
@@ -51,7 +51,7 @@ bool restore_dos(void) {
     }
     
     gotox(0);
-    printf("Loading RAMLink from disk: %3u\n", (unsigned int)(address>>16));
+    printf("Loading RAMLink from disk: %4u\n", (unsigned int)(address>>16));
     
     return true;
 }

--- a/src/restore-reu.c
+++ b/src/restore-reu.c
@@ -34,29 +34,37 @@
 
 bool restore_reu(void) {
     static unsigned long address;
+    static unsigned long block_start = 0;
+    unsigned int reu_block = 0;
+    unsigned int nblocks = (ramlink_size + reu_size - 1)/reu_size;
     
-    printf("Loading REU.\n");
+    printf("Loading REU:  0 of %2u\n", nblocks);
+    printf("Copying REU to RAMLink:    0 of %4u", (unsigned int)(ramlink_size >> 16));
     
+    while(reu_block < nblocks){
+        gotoxy(0, wherey() - 1);
 #if ENABLE_DOS
-    if (ultimate_dos_load_reu(1, 0, ramlink_size) != NULL) {
+    if (ultimate_dos_load_reu(1, 0, reu_size) != NULL) {
         printf("Can't load REU: %s\n", ultimate_ci_status);
         return false;
     }
 #endif
-    
-    printf("Copying REU to RAMLink:   0 of %3u", (unsigned int)(ramlink_size >> 16));
-    for (address = 0; address < ramlink_size; address += BUFFER_SIZE) {
-        gotox(0);
-        printf("Copying REU to RAMLink: %3u", (unsigned int)(address>>16));
+        printf("Loading REU: %2u\n", reu_block + 1);
+        for (address = block_start; address < block_start + reu_size && address < ramlink_size; address += BUFFER_SIZE) {
+            gotox(0);
+            printf("Copying REU to RAMLink: %4u", (unsigned int)(address>>16));
 #if ENABLE_REU
-        reu_copy(address, buffer, BUFFER_SIZE, REU_COMMAND_REU_TO_C64);
+        reu_copy(address - block_start, buffer, BUFFER_SIZE, REU_COMMAND_REU_TO_C64);
 #endif
 #if ENABLE_RAMLINK
         ramlink_reu_copy(address, buffer, BUFFER_SIZE, REU_COMMAND_C64_TO_REU);
 #endif
+        }
+        ++reu_block;
+        block_start += reu_size;
     }
     gotox(0);
-    printf("Copying REU to RAMLink: %3u\n", (unsigned int)(address>>16));
+    printf("Copying REU to RAMLink: %4u\n", (unsigned int)(address>>16));
     
     return true;
 }

--- a/src/restore-reu.c
+++ b/src/restore-reu.c
@@ -33,8 +33,8 @@
 #include <stdio.h>
 
 bool restore_reu(void) {
-    static unsigned long address;
-    static unsigned long block_start = 0;
+    unsigned long address = 0;
+    unsigned long block_start = 0;
     unsigned int reu_block = 0;
     unsigned int nblocks = (ramlink_size + reu_size - 1)/reu_size;
     


### PR DESCRIPTION
I added changes to ramlink_reu_copy.c to accomodate RAMLINK XL sizes. The main change was to incorporate the high address bits into the RAMLINK_REU.address_control register.

In addition, I made changes to backup-reu.c and restore.reu.c to take into account that the RAMLINK XL sizes are often larger than 16MB used in the REU. The code should accomodate different RAMLINK sizes (Regular and XL), as well as different REU sizes. 


